### PR TITLE
update docs for cwctl version

### DIFF
--- a/codewindServer/Versioning.md
+++ b/codewindServer/Versioning.md
@@ -1,4 +1,4 @@
-## How to report versioning back to user
+# Reporting Codewind versions
 
 Codewind now consists of several components each having their own binary.
 
@@ -6,41 +6,50 @@ Codewind now consists of several components each having their own binary.
 2. codewind-pfe
 3. codewind-performance
 4. codewind-keycloak
-5. codewind-gateway
+5. codewind-gatekeeper
 
-Each of these needs to correctly be able to report its version back to the user to help with debugging mis match of levels.
+Each of these needs to correctly be able to report its version back to the user to help with debugging mismatch of levels.
 
-###### Steps for user of cwctl
+## Steps for cwctl user
 
-cwctl will require the -version option as well as an optional connectionID if you want to get the versions of a remotely deployed codewind.
+Cwctl will require the `version` option as well as an optional `connectionID` if you want to get the versions of a remotely deployed Codewind.
 
-`cwctl -version <-connID value>` 
+Command
 
-output
+```bash
+cwctl version --insecure --connID <value>
+```
 
-`cwctl version x.x.x`<br/>
-`codewind-pfe-amd64 x.x.x.imageID`<br/>
-`codewind-performance-amd64 x.x.x.imageID`<br/>
-`codewind-keycloak-amd64 x.x.x.imageID`<br/>
-`codewind-gatekeeper-amd64 x.x.x.imageID`<br/>
+Output
+
+```bash
+{
+    "CwctlVersion": "x.x.x"
+    "PFEVersion": "x.x.x.imageBuildTime"
+    "PerformanceVersion": "x.x.x.imageBuildTime"
+    "GatekeeperVersion": "x.x.x.imageBuildTime"
+}
+```
 
 Example
 
-`cwctl version 0.6.0`<br/>
-`codewind-pfe-amd64 0.6.0.23bd1a58b015`<br/>
-`codewind-performance-amd64 0.6.0.9d6e9b75db3d`<br/>
-`codewind-keycloak-amd64 0.6.0.d234ada371ed`<br/>
-`codewind-gatekeeper-amd64 0.6.0.da86e6ba6ca1`<br/>
+```bash
+{
+    "CwctlVersion": "0.6.0"
+    "PFEVersion": "0.6.0-20191203-132736"
+    "PerformanceVersion": "0.6.0-20191203-132736"
+    "GatekeeperVersion": "0.6.0-20191203-132736"
+}
+```
 
-### What if the versions don't match?
+### If versions don't match
 
-If cwctl detects that the version of itself is not at the same level as codewind-pfe, we should output a warning to the user and advise them to update.  This is critical as the cwctl may be attempting to invoke commands that are not available in old levels
+If cwctl detects that the version of itself is not at the same level as Codewind PFE, we should output a warning to the user and advise them to update.  This is critical as the cwctl may be attempting to invoke commands that are not available in old levels.
 
-## Deploying codewind with versions
+## Deploying Codewind with versions
 
-To make things simpler when deploying, cwctl can be passed an option release tag when installing.  This tag will specfiy the version of codewind to install. If the tag is not supplied then the latest master images are installed.
+To make things simpler when deploying, cwctl can be passed an option release tag when installing.  This tag will specify the version of Codewind to install. If the tag is not supplied then the latest master images are installed.
 
 `cwctl install <-tag tagname>`
 
-We should prevent a back level version of cwctl installing a later version of codewind as this would not be a supported environment.
-
+We should prevent a back level version of cwctl installing a later version of Codewind as this would not be a supported environment.

--- a/codewindServer/Versioning.md
+++ b/codewindServer/Versioning.md
@@ -44,12 +44,12 @@ Example
 
 ### If versions don't match
 
-If cwctl detects that the version of itself is not at the same level as Codewind PFE, we should output a warning to the user and advise them to update.  This is critical as the cwctl may be attempting to invoke commands that are not available in old levels.
+If cwctl detects that the version of itself is not at the same level as Codewind PFE, cwctl will output a warning to the user and advise them to update.  This is critical as the cwctl may be attempting to invoke commands that are not available in old levels.
 
 ## Deploying Codewind with versions
 
-To make things simpler when deploying, cwctl can be passed an option release tag when installing.  This tag will specify the version of Codewind to install. If the tag is not supplied then the latest master images are installed.
+Cwctl can be passed an option release tag when installing.  This tag will specify the version of Codewind to install. If the tag is not supplied then the latest master images are installed.
 
 `cwctl install <-tag tagname>`
 
-We should prevent a back level version of cwctl installing a later version of Codewind as this would not be a supported environment.
+Cwctl prevents a back level version of cwctl installing a later version of Codewind as this would not be a supported environment.


### PR DESCRIPTION
Updates version docs, to match the output for `cwctl version`. Also some minor tidying.

Signed-off-by: James Cockbain <james.cockbain@ibm.com>